### PR TITLE
fix my licensing mistake

### DIFF
--- a/Character Sheet.tex
+++ b/Character Sheet.tex
@@ -30,6 +30,7 @@
 		},
 		Inspiration={5},
 		Proficiencies={
+			Bonus=3,
 			Wisdom,
 			Charisma,
 			Dexterity=2,

--- a/dndcharactersheet.sty
+++ b/dndcharactersheet.sty
@@ -60,6 +60,7 @@
 \define@key[DndBase]{Abilities}{Wisdom}{\def\@DndBase@Abilities@Wisdom{#1}}
 \define@key[DndBase]{Abilities}{Charisma}{\def\@DndBase@Abilities@Charisma{#1}}
 
+\define@key[DndBase]{Proficiencies}{Bonus}{\def\@DndBase@Proficiencies@Bonus{#1}}
 \define@key[DndBase]{Proficiencies}{Strength}[1]{\def\@DndBase@Proficiencies@Strength{#1}}
 \define@key[DndBase]{Proficiencies}{Dexterity}[1]{\def\@DndBase@Proficiencies@Dexterity{#1}}
 \define@key[DndBase]{Proficiencies}{Constitution}[1]{\def\@DndBase@Proficiencies@Constitution{#1}}
@@ -121,40 +122,6 @@
 
 
 \ExplSyntaxOn
-
-\NewExpandableDocumentCommand\DndLevel{m}{
-	\int_compare:nTF {#1 < 300}		{1}
-	{\int_compare:nTF {#1 < 900}	{2}
-	{\int_compare:nTF {#1 < 2700}	{3}
-	{\int_compare:nTF {#1 < 6500}	{4}
-	{\int_compare:nTF {#1 < 14000}	{5}
-	{\int_compare:nTF {#1 < 23000}	{6}
-	{\int_compare:nTF {#1 < 34000}	{7}
-	{\int_compare:nTF {#1 < 48000}	{8}
-	{\int_compare:nTF {#1 < 64000}	{9}
-	{\int_compare:nTF {#1 < 85000}	{10}
-	{\int_compare:nTF {#1 < 100000}	{11}
-	{\int_compare:nTF {#1 < 120000}	{12}
-	{\int_compare:nTF {#1 < 140000}	{13}
-	{\int_compare:nTF {#1 < 165000}	{14}
-	{\int_compare:nTF {#1 < 195000}	{15}
-	{\int_compare:nTF {#1 < 225000}	{16}
-	{\int_compare:nTF {#1 < 265000}	{17}
-	{\int_compare:nTF {#1 < 305000}	{18}
-	{\int_compare:nTF {#1 < 355000}	{19}
-									{20}
-	}}}}}}}}}}}}}}}}}}
-}
-
-\NewExpandableDocumentCommand\DndProficiencyBonus{m}{
-	\int_compare:nTF {#1 < 5}	{2}
-	{\int_compare:nTF {#1 < 9}	{3}
-	{\int_compare:nTF {#1 < 13}	{4}
-	{\int_compare:nTF {#1 < 17}	{5}
-								{6}
-	}}}
-}
-
 \NewExpandableDocumentCommand\DndGetAbilityModifier{m}{
 	\fp_eval:n{trunc(#1 / 2 - 5, 0)}
 }
@@ -171,12 +138,14 @@
 }
 
 \NewExpandableDocumentCommand\DndGetSavingThrow{m m}{
-	\fp_eval:n{#1 + #2 * \DndProficiencyBonus{\DndLevel{\@DndBase@Character@Exp}}}
+	\fp_eval:n{#1 + #2 * \@DndBase@Proficiencies@Bonus}
 }
+
 
 \NewExpandableDocumentCommand\DndGetPassiveWisdom{}{
 	\fp_eval:n{10 + \DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}
 }
+
 
 \ExplSyntaxOff
 
@@ -307,7 +276,9 @@
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 		%
-		\node[draw=none,rectangle,text width=0.5 cm,align=center] at (-0.56,-3.27) {\DndDisplaySignedNum{\DndProficiencyBonus{\DndLevel{\@DndBase@Character@Exp}}}};
+		\ifdefined\@DndBase@Proficiencies@Bonus
+			\node[draw=none,rectangle,text width=0.5 cm,align=center] at (-0.56,-3.27) {\DndDisplaySignedNum{\@DndBase@Proficiencies@Bonus}};
+		\fi
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 		%
@@ -347,35 +318,37 @@
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 		%
-		% Strength
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-4.45) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Strength}}{\@DndBase@Proficiencies@Strength}}};
-		\fi
-		% Dexterity
-		\ifdefined\@DndBase@Abilities@Dexterity
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-4.91) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Proficiencies@Dexterity}}};
-		\fi
-		% Constitution
-		\ifdefined\@DndBase@Abilities@Constitution
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-5.37) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Constitution}}{\@DndBase@Proficiencies@Constitution}}};
-		\fi
-		% Intelligence
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-5.84) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Proficiencies@Intelligence}}};
-		\fi
-		% Wisdom
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-6.30) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Proficiencies@Wisdom}}};
-		\fi
-		% Charisma
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-6.76) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Proficiencies@Charisma}}};
+		\ifdefined\@DndBase@Proficiencies@Bonus
+			% Strength
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-4.45) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Strength}}{\@DndBase@Proficiencies@Strength}}};
+			\fi
+			% Dexterity
+			\ifdefined\@DndBase@Abilities@Dexterity
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-4.91) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Proficiencies@Dexterity}}};
+			\fi
+			% Constitution
+			\ifdefined\@DndBase@Abilities@Constitution
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-5.37) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Constitution}}{\@DndBase@Proficiencies@Constitution}}};
+			\fi
+			% Intelligence
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-5.84) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Proficiencies@Intelligence}}};
+			\fi
+			% Wisdom
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-6.30) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Proficiencies@Wisdom}}};
+			\fi
+			% Charisma
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-6.76) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Proficiencies@Charisma}}};
+			\fi
 		\fi
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -464,95 +437,97 @@
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 		%
-		% Acrobatics
-		\ifdefined\@DndBase@Abilities@Dexterity
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 8.40) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@Acrobatics}}};
-		\fi
-		% Animal handling
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 8.86) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Animals}}};
-		\fi
-		% Arcana
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 9.33) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Arcana}}};
-		\fi
-		% Athletics
-		\ifdefined\@DndBase@Abilities@Strength
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 9.79) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Strength}}{\@DndBase@Skills@Athletics}}};
-		\fi
-		% Deception
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-10.26) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Deception}}};
-		\fi
-		% History
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-10.72) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@History}}};
-		\fi
-		% Insight
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-11.18) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Insight}}};
-		\fi
-		% Intimidation
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-11.65) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Intimidation}}};
-		\fi
-		% Investigation
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-12.11) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Investigation}}};
-		\fi
-		% Medicine
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-12.58) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Medicine}}};
-		\fi
-		% Nature
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.04) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Nature}}};
-		\fi
-		% Perception
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.50) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Perception}}};
-		\fi
-		% Performance
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.96) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Performance}}};
-		\fi
-		% Persuasion
-		\ifdefined\@DndBase@Abilities@Charisma
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-14.43) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Persuasion}}};
-		\fi
-		% Religion
-		\ifdefined\@DndBase@Abilities@Intelligence
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-14.89) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Religion}}};
-		\fi
-		% Sleight of hand
-		\ifdefined\@DndBase@Abilities@Dexterity
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-15.36) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@SleightOfHand}}};
-		\fi
-		% Stealth
-		\ifdefined\@DndBase@Abilities@Dexterity
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-15.82) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@Stealth}}};
-		\fi
-		% Survival
-		\ifdefined\@DndBase@Abilities@Wisdom
-			\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-16.28) {\small 
-				\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Survival}}};
+		\ifdefined\@DndBase@Proficiencies@Bonus
+			% Acrobatics
+			\ifdefined\@DndBase@Abilities@Dexterity
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 8.40) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@Acrobatics}}};
+			\fi
+			% Animal handling
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 8.86) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Animals}}};
+			\fi
+			% Arcana
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 9.33) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Arcana}}};
+			\fi
+			% Athletics
+			\ifdefined\@DndBase@Abilities@Strength
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,- 9.79) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Strength}}{\@DndBase@Skills@Athletics}}};
+			\fi
+			% Deception
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-10.26) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Deception}}};
+			\fi
+			% History
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-10.72) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@History}}};
+			\fi
+			% Insight
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-11.18) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Insight}}};
+			\fi
+			% Intimidation
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-11.65) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Intimidation}}};
+			\fi
+			% Investigation
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-12.11) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Investigation}}};
+			\fi
+			% Medicine
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-12.58) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Medicine}}};
+			\fi
+			% Nature
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.04) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Nature}}};
+			\fi
+			% Perception
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.50) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Perception}}};
+			\fi
+			% Performance
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-13.96) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Performance}}};
+			\fi
+			% Persuasion
+			\ifdefined\@DndBase@Abilities@Charisma
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-14.43) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Charisma}}{\@DndBase@Skills@Persuasion}}};
+			\fi
+			% Religion
+			\ifdefined\@DndBase@Abilities@Intelligence
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-14.89) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Intelligence}}{\@DndBase@Skills@Religion}}};
+			\fi
+			% Sleight of hand
+			\ifdefined\@DndBase@Abilities@Dexterity
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-15.36) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@SleightOfHand}}};
+			\fi
+			% Stealth
+			\ifdefined\@DndBase@Abilities@Dexterity
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-15.82) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Dexterity}}{\@DndBase@Skills@Stealth}}};
+			\fi
+			% Survival
+			\ifdefined\@DndBase@Abilities@Wisdom
+				\node[draw=none,rectangle,text width=0.5 cm,align=right] at (-0.20,-16.28) {\small 
+					\DndDisplaySignedNum{\DndGetSavingThrow{\DndGetAbilityModifier{\@DndBase@Abilities@Wisdom}}{\@DndBase@Skills@Survival}}};
+			\fi
 		\fi
 		%
 		%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I actually was hoping to submit a different pull request today regarding my [alternative branch](https://github.com/pepper-jk/DnD-Latex-Charactersheet/tree/alternative). For this I wanted to host modified Character Sheets, which include Honor and/or Sanity as Abilities. This is why, I did some digging into the [Fan Content Policy](https://company.wizards.com/fancontentpolicy), the [Systems Reference Document](http://dnd.wizards.com/articles/features/systems-reference-document-srd) and the [Open Game License](http://www.opengamingfoundation.org/ogl.html).

After reading the license I found a mistake in my last pull request regarding the commands I wrote for the Character Level and Proficiency Bonus Calculation. It looks like they need to be licensed under the [Open Game License](http://www.opengamingfoundation.org/ogl.html), since they are based on the tables written in the [Systems Reference Document](http://dnd.wizards.com/articles/features/systems-reference-document-srd). Since this is incompatible with the GPL, this pull request removes my changes, which have this issue.

Sorry for the mess.